### PR TITLE
Fix promotion for combine

### DIFF
--- a/src/operators.jl
+++ b/src/operators.jl
@@ -5,6 +5,9 @@ Base.zero(::Type{Polynomial{C, T, A}}) where {C, T, A} = Polynomial(A())
 Base.zero(t::PolynomialLike) = zero(typeof(t))
 
 combine(t1::Term, t2::Term) = combine(promote(t1, t2)...)
+function MA.promote_operation(::typeof(combine), ::Type{Term{S, M1}}, ::Type{Term{T, M2}}) where {S, T, M1, M2}
+    return Term{MA.promote_operation(+, S, T), promote_type(M1, M2)}
+end
 combine(t1::T, t2::T) where {T <: Term} = Term(t1.coefficient + t2.coefficient, t1.monomial)
 compare(t1::Term, t2::Term) = monomial(t1) > monomial(t2)
 

--- a/src/sequences.jl
+++ b/src/sequences.jl
@@ -1,6 +1,7 @@
 module Sequences
 
-
+import MutableArithmetics
+const MA = MutableArithmetics
 
 export shortest_common_supersequence
 
@@ -129,7 +130,7 @@ end
 
 function mergesorted(v1::AbstractArray, v2::AbstractArray, isless=Base.isless,
                      combine=Base.:+, filter=x -> !iszero(x))
-    T = Base.promote_op(combine, eltype(v1), eltype(v2))
+    T = MA.promote_operation(combine, eltype(v1), eltype(v2))
     result = Vector{T}(undef, length(v1) + length(v2))
     mergesorted!(result, v1, v2, isless, combine, filter)
 end


### PR DESCRIPTION
This `Base.promote_op` does not work with two vectors of `Term{Sym,Monomial{(x,),1}}`:
https://github.com/JuliaAlgebra/TypedPolynomials.jl/blob/acceba34d3781e9e7944e2922ca08448e1784a9d/src/sequences.jl#L132
It is unable to infer the coefficient type and give the failure reported in https://github.com/JuliaAlgebra/TypedPolynomials.jl/issues/60.
It is not advised to use `promote_op` and MutableArithmetic's `promote_operation` was created precisely as a replacement for this kind of use cases. Instead of relying on the Julia inference, here we simply implement a `promote_operation` method.

Closes https://github.com/JuliaAlgebra/TypedPolynomials.jl/issues/60